### PR TITLE
HillHacks 2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,19 @@ permalink: /
 ---
 <div class="header row">
     <div class="row logo"></div>
-    <h1>Hacking and making in the Himalayas</h1>
-    <h3>Thachi Valley, Himachal Pradesh, India</h3>
-    <h3>13th - 28th May 2023</h3>
+    <h1>Hacking and making in the Hills</h1>
+    <h3>India</h3>
+    <h3>Dates to be announced</h3>
     <div class="row cta-row">
         <div class="col-md-4 col-sm-4 col-sm-offset-2">
-            <a href="{{site.baseurl}}/register/">
-                <button type="button" class="btn btn-default btn-lg btn-block cta-1">Register to attend</button>
-            </a>
+            <!-- <a href="{{site.baseurl}}/register/"> -->
+            <!--     <button type="button" class="btn btn-default btn-lg btn-block cta-1">Register to attend</button> -->
+            <!-- </a> -->
         </div>
         <div class="col-md-4 col-sm-4">
-            <a href="{{site.baseurl}}/participate/">
-                <button type="button" class="btn btn-primary btn-lg btn-block cta-2">Propose a session</button>
-            </a>
+            <!-- <a href="{{site.baseurl}}/participate/"> -->
+            <!--     <button type="button" class="btn btn-primary btn-lg btn-block cta-2">Propose a session</button> -->
+            <!-- </a> -->
         </div>
     </div>
 </div>

--- a/pages/about.md
+++ b/pages/about.md
@@ -4,7 +4,7 @@ title: What we do
 permalink: /about/
 ---
 Hillhacks has been held in the lap of the stunning Dhauladhar Himalayas every summer in 
-the state of Himachal Pradesh. There is buzz of having it other hilly regions in India 
+the state of Himachal Pradesh. There is some buzz of having it in other hilly regions in India, checkout the [mailing list](/contact/) for more information.
 in the upcoming editions.
 
 People from different places, walks of life and lines of thought come together

--- a/pages/about.md
+++ b/pages/about.md
@@ -3,8 +3,9 @@ layout: page
 title: What we do
 permalink: /about/
 ---
-
-hillhacks is held in the lap of the stunning Dhauladhar Himalayas every summer.
+hillhacks has been held in the lap of the stunning Dhauladhar Himalayas every summer in 
+the state of Himachal Pradesh. There is buzz of having it other hilly regions in India 
+in the upcoming editions.
 
 People from different places, walks of life and lines of thought come together
 to share, collaborate and learn.

--- a/pages/about.md
+++ b/pages/about.md
@@ -3,7 +3,7 @@ layout: page
 title: What we do
 permalink: /about/
 ---
-hillhacks has been held in the lap of the stunning Dhauladhar Himalayas every summer in 
+Hillhacks has been held in the lap of the stunning Dhauladhar Himalayas every summer in 
 the state of Himachal Pradesh. There is buzz of having it other hilly regions in India 
 in the upcoming editions.
 


### PR DESCRIPTION
Changes to the homepage and about page for 2024 edition of hillhacks

  - Remove the dates from previous year,  and add a message on dates to be announced
  - changed the word in quote from Himalayas to Hills because of a possibility of change in venue this time.
  - removed the buttons for registrations and cfp
  - added a small text for the location of hillhacks on about page.